### PR TITLE
Support any flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ The nix-playground is a command line tool that makes applying patches to the nix
 
 ```bash
 # checkout libnvidia-container package source code locally
-# (in `nixpkgs` by default, a full pkg path with flake name can be provided like `nixpkgs#cowsay`)
-np checkout libnvidia-container
+np checkout nixpkgs#libnvidia-container
 
 # modify the code
 vim checkout/src/cli/main.c
@@ -75,17 +74,20 @@ with import <nixpkgs> {};
 ### Checkout
 
 1. Create `.nix-playground` folder in the current directory
-2. Call `nix-instantiate` to generate the derivation for the target package with a link at `.nix-playground/der`
+2. Call `nix derivation show` to output the derivation as a json file at `.nix-playground/drv.json`
 3. Get the `env.src` nix store path from the generated derivation 
 4. Run `nix-store --realise` to realise the package and its source derivation with links in the `.nix-playground` folder.
-5. Deep copy the source (from env.src) folder to the current directory's `checkout` folder
+5. Deep copy the source (from env.src) folder, or untar it to the current directory's `checkout` folder
 6. Init a git repo in the `checkout` folder and commit all the changes
 7. Apply patches from the package as commits in the `checkout` Git repo if there's any
 
 ### Build
 
 1. Get the cached diff with git for the `checkout` folder and output the patch file to `.nix-playground/checkout.patch`
-2. Run `nix-build --expr` with patch file applied to the target package
+2. Insert patch into the payload from `.nix-playground/drv.json`
+3. Call `nix derivation add` to add the derivation with patch added
+4. Read output patch does not match error, if there's any, patch the derivation payload and jump to step.3 and try again
+5. Realize the patched derivation and build
 
 ## Roadmap
 

--- a/nix_playground/build.py
+++ b/nix_playground/build.py
@@ -36,14 +36,18 @@ def main(env: Environment):
         for patch in repo.diff(cached=True):
             fo.write(patch.text)
     patch_path = np_dir / constants.PATCH_FILE
-    patch_store_path = subprocess.check_output(
-        [
-            "nix",
-            "store",
-            "add",
-            str(patch_path),
-        ]
-    ).decode("utf8")
+    patch_store_path = (
+        subprocess.check_output(
+            [
+                "nix",
+                "store",
+                "add",
+                str(patch_path),
+            ]
+        )
+        .decode("utf8")
+        .strip()
+    )
     logger.info("Added patch file to store as %s", patch_store_path)
 
     logger.info("Building nix package with patch")
@@ -64,8 +68,8 @@ def main(env: Environment):
     else:
         patches = []
     patches.append(patch_store_path)
-
     drv_payload["env"]["patches"] = " ".join(patches)
+    drv_payload["inputSrcs"].append(patch_store_path)
 
     # This is a hack, we expect the `nix derivation add` command to return an error like this:
     #

--- a/nix_playground/build.py
+++ b/nix_playground/build.py
@@ -1,5 +1,5 @@
+import json
 import logging
-import pathlib
 import subprocess
 import textwrap
 
@@ -33,17 +33,62 @@ def main(env: Environment):
     with path_file.open("wt") as fo:
         for patch in repo.diff(cached=True):
             fo.write(patch.text)
-    logger.info("Building nix package with patch")
-    subprocess.check_call(
+    patch_path = np_dir / constants.PATCH_FILE
+    patch_store_path = subprocess.check_output(
         [
-            "nix-build",
-            "--expr",
-            textwrap.dedent(f"""\
-    with import <{package.flake}> {{}};
-        {package.attr_name}.overrideAttrs (oldAttrs: {{
-            patches = (lib.attrsets.attrByPath ["patches"] [] oldAttrs) ++ [{np_dir / constants.PATCH_FILE}];
-        }})
-    """),
+            "nix",
+            "store",
+            "add",
+            str(patch_path),
         ]
+    ).decode("utf8")
+    logger.info("Added patch file to store as %s", patch_store_path)
+
+    logger.info("Building nix package with patch")
+
+    der_json_path = np_dir / constants.DER_JSON_FILE
+    with der_json_path.open("rb") as fo:
+        der_payloads = json.load(fo)
+
+    if len(der_payloads) != 1:
+        raise ValueError("Expected only one der in the payload")
+
+    der_path = list(der_payloads.keys())[0]
+    der_payload = der_payloads[der_path]
+
+    patches = der_payload["env"].get("patches", "")
+    if patches:
+        patches = patches.split(" ")
+    else:
+        patches = []
+    patches.append(patch_store_path)
+
+    der_payload["env"]["patches"] = " ".join(patches)
+
+    # This is a hack, we expect the `nix derivation add` command to return an error like this:
+    #
+    #   error: derivation '/nix/store/k4lb25pvzr0magkpk04c1mw69ix73gnf-hello-2.12.1.drv' has incorrect output
+    #   '/nix/store/p09fxxwkdj69hk4mgddk4r3nassiryzc-hello-2.12.1',
+    #   should be '/nix/store/ja3hh4izqsjzq3rh8fxdqxw7vf56pw9m-hello-2.12.1'
+    #
+    # So that we can get the correct output path
+    proc = subprocess.run(
+        ["nix", "derivation", "add"],
+        input=json.dumps(der_payload).encode("utf8"),
+        stderr=subprocess.PIPE,
     )
+    if proc.returncode == 0:
+        raise ValueError("Does not expect this command to work")
+    proc.stderr
+
+    # logger.debug("Running nix expr:\n%s", nix_expr)
+    # subprocess.check_call(
+    #     [
+    #         "nix",
+    #         "build",
+    #         "--impure",
+    #         "--expr",
+    #         nix_expr,
+    #     ]
+    # )
     logger.info("done")

--- a/nix_playground/checkout.py
+++ b/nix_playground/checkout.py
@@ -40,6 +40,8 @@ def main(env: Environment, pkg_name: str, checkout_to: str | None):
     logger.info("Checkout out package %s ...", pkg_name)
     with switch_cwd(np_dir):
         try:
+            # TODO: do "nix derivation show nixpkgs#hello" instead,
+            #       it's much easier
             der_metadata = json.loads(
                 subprocess.check_output(
                     [
@@ -54,7 +56,6 @@ def main(env: Environment, pkg_name: str, checkout_to: str | None):
             der_path = list(der_metadata.keys())[0]
             # TODO: ideally should find a way to keep the derivation from gc?
         except subprocess.CalledProcessError:
-            raise
             logger.error("Failed to fetch package der info %s", pkg_name)
             sys.exit(-1)
         logger.info("Got package der path %s", der_path)

--- a/nix_playground/checkout.py
+++ b/nix_playground/checkout.py
@@ -40,28 +40,23 @@ def main(env: Environment, pkg_name: str, checkout_to: str | None):
     logger.info("Checkout out package %s ...", pkg_name)
     with switch_cwd(np_dir):
         try:
-            # TODO: do "nix derivation show nixpkgs#hello" instead,
-            #       it's much easier
-            der_metadata = json.loads(
+            der_payload = json.loads(
                 subprocess.check_output(
                     [
                         "nix",
-                        "path-info",
-                        "--json",
-                        "--derivation",
+                        "derivation",
+                        "show",
                         pkg_name,
                     ]
                 )
             )
-            der_path = list(der_metadata.keys())[0]
+            der_path = list(der_payload.keys())[0]
             # TODO: ideally should find a way to keep the derivation from gc?
         except subprocess.CalledProcessError:
             logger.error("Failed to fetch package der info %s", pkg_name)
             sys.exit(-1)
         logger.info("Got package der path %s", der_path)
-        der_payload = json.loads(
-            subprocess.check_output(["nix", "derivation", "show", der_path])
-        )
+
         logger.debug("Der payload: %r", der_payload)
         src = der_payload[der_path]["env"].get("src")
         logger.info("Source of the der %r", src)

--- a/nix_playground/checkout.py
+++ b/nix_playground/checkout.py
@@ -119,7 +119,8 @@ def main(env: Environment, pkg_name: str, checkout_to: str | None):
             logger.info("Extract tar.gz file %s into %s", src_path, checkout_dir)
             checkout_dir.mkdir(exist_ok=True)
             with src_path.open("rb") as fo, switch_cwd(checkout_dir):
-                extract_tar(fo)
+                # TODO: is it always 1?
+                extract_tar(fo, strip_path_count=1)
         # TODO: support other format
         else:
             logger.error("Unsupported src (%s) type, don't know how to handle", src)

--- a/nix_playground/checkout.py
+++ b/nix_playground/checkout.py
@@ -39,7 +39,7 @@ def main(env: Environment, pkg_name: str, checkout_to: str | None):
     logger.info("Checkout out package %s ...", pkg_name)
     with switch_cwd(np_dir):
         try:
-            der_payload = json.loads(
+            drv_payload = json.loads(
                 subprocess.check_output(
                     [
                         "nix",
@@ -49,29 +49,29 @@ def main(env: Environment, pkg_name: str, checkout_to: str | None):
                     ]
                 )
             )
-            if len(der_payload) != 1:
+            if len(drv_payload) != 1:
                 raise ValueError("Expected only one der in the payload")
-            der_path = pathlib.Path(list(der_payload.keys())[0])
-            der_json_file = pathlib.Path(constants.DER_JSON_FILE)
-            with der_json_file.open("wt") as fo:
-                json.dump(der_payload, fo)
+            drv_path = pathlib.Path(list(drv_payload.keys())[0])
+            drv_json_file = pathlib.Path(constants.DRV_JSON_FILE)
+            with drv_json_file.open("wt") as fo:
+                json.dump(drv_payload, fo)
         except subprocess.CalledProcessError:
             logger.error("Failed to fetch package der info %s", pkg_name)
             sys.exit(-1)
-        logger.info("Got package der path %s", der_path)
+        logger.info("Got package der path %s", drv_path)
 
-        logger.debug("Der payload: %r", der_payload)
-        src = der_payload[str(der_path)]["env"].get("src")
+        logger.debug("Der payload: %r", drv_payload)
+        src = drv_payload[str(drv_path)]["env"].get("src")
         logger.info("Source of the der %r", src)
 
-        logger.info("Realizing der %s ...", der_path)
+        logger.info("Realizing der %s ...", drv_path)
         subprocess.check_call(
             [
                 "nix-store",
                 "--realise",
                 "--add-root",
                 constants.PKG_LINK,
-                str(der_path),
+                str(drv_path),
             ]
         )
 
@@ -85,7 +85,7 @@ def main(env: Environment, pkg_name: str, checkout_to: str | None):
             ]
         )
         patch_files = []
-        patches = der_payload[str(der_path)]["env"].get("patches", "").strip()
+        patches = drv_payload[str(drv_path)]["env"].get("patches", "").strip()
         if patches:
             patch_files = patches.split(" ")
             logger.info("Found package patches %s, realizing ...", patch_files)

--- a/nix_playground/constants.py
+++ b/nix_playground/constants.py
@@ -4,8 +4,8 @@ PLAYGROUND_DIR = ".nix-playground"
 # .nix-playground/pkg_name
 PKG_NAME = "pkg_name"
 # the filename of JSON dump from nix der file in the PLAYGROUND_DIR folder, like
-# .nix-playground/der.json
-DER_JSON_FILE = "der.json"
+# .nix-playground/drv.json
+DRV_JSON_FILE = "drv.json"
 # the filename of link to nix package in the PLAYGROUND_DIR folder, like
 # .nix-playground/pkg
 PKG_LINK = "pkg"

--- a/nix_playground/constants.py
+++ b/nix_playground/constants.py
@@ -3,9 +3,9 @@ PLAYGROUND_DIR = ".nix-playground"
 # the filename of original checked out package name in the PLAYGROUND_DIR folder, like
 # .nix-playground/pkg_name
 PKG_NAME = "pkg_name"
-# the filename of link to nix der in the PLAYGROUND_DIR folder, like
-# .nix-playground/der
-DER_LINK = "der"
+# the filename of JSON dump from nix der file in the PLAYGROUND_DIR folder, like
+# .nix-playground/der.json
+DER_JSON_FILE = "der.json"
 # the filename of link to nix package in the PLAYGROUND_DIR folder, like
 # .nix-playground/pkg
 PKG_LINK = "pkg"

--- a/nix_playground/constants.py
+++ b/nix_playground/constants.py
@@ -12,6 +12,9 @@ PKG_LINK = "pkg"
 # the filename of link to nix source code in the PLAYGROUND_DIR folder, like
 # .nix-playground/src
 SRC_LINK = "src"
+# the filename of link to nix build output in the PLAYGROUND_DIR folder, like
+# .nix-playground/result
+RESULT_LINK = "result"
 # the filename of link to checked out folder in PLAYGROUND_DIR folder, like
 # .nix-playground/checkout
 CHECKOUT_LINK = "checkout"

--- a/nix_playground/utils.py
+++ b/nix_playground/utils.py
@@ -44,10 +44,21 @@ def ensure_np_dir() -> pathlib.Path:
     return np_dir
 
 
-def extract_tar(input_file: io.BytesIO, mode: str = "r:gz"):
-    with tarfile.open(fileobj=input_file, mode="r:gz") as tar_file:
+def strip_path(strip_count: int, tar: tarfile.TarFile):
+    for member in tar.getmembers():
+        member.path = member.path.split("/", strip_count)[-1]
+        yield member
+
+
+def extract_tar(
+    input_file: io.BytesIO, mode: str = "r:gz", strip_path_count: int | None = None
+):
+    with tarfile.open(fileobj=input_file, mode=mode) as tar_file:
+        extra_kwargs = {}
+        if strip_path_count:
+            extra_kwargs["members"] = strip_path(strip_path_count, tar_file)
         if hasattr(tarfile, "data_filter"):
-            tar_file.extractall(filter="data")
+            tar_file.extractall(filter="data", **extra_kwargs)
         else:
             logger.warning("Performing unsafe tar file extracting")
-            tar_file.extractall()
+            tar_file.extractall(**extra_kwargs)

--- a/nix_playground/utils.py
+++ b/nix_playground/utils.py
@@ -1,9 +1,11 @@
 import contextlib
 import dataclasses
+import io
 import logging
 import os
 import pathlib
 import sys
+import tarfile
 import typing
 
 from . import constants
@@ -40,3 +42,12 @@ def ensure_np_dir() -> pathlib.Path:
         logger.info("No checkout found in the current folder")
         sys.exit(-1)
     return np_dir
+
+
+def extract_tar(input_file: io.BytesIO, mode: str = "r:gz"):
+    with tarfile.open(fileobj=input_file, mode="r:gz") as tar_file:
+        if hasattr(tarfile, "data_filter"):
+            tar_file.extractall(filter="data")
+        else:
+            logger.warning("Performing unsafe tar file extracting")
+            tar_file.extractall()

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -11,6 +11,10 @@ from nix_playground.utils import switch_cwd
     "pkg_name, expected_result_files",
     [
         ("nixpkgs#cowsay", [pathlib.Path("bin") / "cowsay"]),
+        (
+            "github:NixOS/nixpkgs/a3a3dda3bacf61e8a39258a0ed9c924eeca8e293#cowsay",
+            [pathlib.Path("bin") / "cowsay"],
+        ),
         ("nixpkgs#hello", [pathlib.Path("bin") / "hello"]),
         ("nixpkgs#libnvidia-container", [pathlib.Path("bin") / "nvidia-container-cli"]),
     ],

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -11,9 +11,7 @@ from nix_playground.utils import switch_cwd
     "pkg_name, expected_result_files",
     [
         ("nixpkgs#cowsay", [pathlib.Path("bin") / "cowsay"]),
-        ("cowsay", [pathlib.Path("bin") / "cowsay"]),
         ("nixpkgs#libnvidia-container", [pathlib.Path("bin") / "nvidia-container-cli"]),
-        ("libnvidia-container", [pathlib.Path("bin") / "nvidia-container-cli"]),
     ],
 )
 def test_build(

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -11,6 +11,7 @@ from nix_playground.utils import switch_cwd
     "pkg_name, expected_result_files",
     [
         ("nixpkgs#cowsay", [pathlib.Path("bin") / "cowsay"]),
+        ("nixpkgs#hello", [pathlib.Path("bin") / "hello"]),
         ("nixpkgs#libnvidia-container", [pathlib.Path("bin") / "nvidia-container-cli"]),
     ],
 )

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -12,9 +12,7 @@ from nix_playground.utils import switch_cwd
     "pkg_name, expected_checkout_files",
     [
         ("nixpkgs#cowsay", [pathlib.Path("bin") / "cowsay"]),
-        ("cowsay", [pathlib.Path("bin") / "cowsay"]),
         ("nixpkgs#libnvidia-container", [pathlib.Path("src") / "cli" / "main.c"]),
-        ("libnvidia-container", [pathlib.Path("src") / "cli" / "main.c"]),
     ],
 )
 def test_checkout(
@@ -33,7 +31,7 @@ def test_checkout(
     pkg_name_file = np_dir / constants.PKG_NAME
     assert pkg_name_file.read_text() == pkg_name
 
-    der_link = np_dir / constants.DER_LINK
+    der_link = np_dir / constants.DER_JSON_FILE
     assert der_link.exists()
     pkg_link = np_dir / constants.PKG_LINK
     assert pkg_link.exists()

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -12,6 +12,7 @@ from nix_playground.utils import switch_cwd
     "pkg_name, expected_checkout_files",
     [
         ("nixpkgs#cowsay", [pathlib.Path("bin") / "cowsay"]),
+        ("nixpkgs#hello", [pathlib.Path("src") / "hello.c"]),
         ("nixpkgs#libnvidia-container", [pathlib.Path("src") / "cli" / "main.c"]),
     ],
 )

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -31,8 +31,8 @@ def test_checkout(
     pkg_name_file = np_dir / constants.PKG_NAME
     assert pkg_name_file.read_text() == pkg_name
 
-    der_link = np_dir / constants.DER_JSON_FILE
-    assert der_link.exists()
+    drv_json_file = np_dir / constants.DRV_JSON_FILE
+    assert drv_json_file.exists()
     pkg_link = np_dir / constants.PKG_LINK
     assert pkg_link.exists()
     src_link = np_dir / constants.SRC_LINK

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -11,9 +11,9 @@ from nix_playground.utils import switch_cwd
 @pytest.mark.parametrize(
     "pkg_name, checkout_dir_name",
     [
-        ("cowsay", None),
-        ("cowsay", "my_checkout"),
-        ("libnvidia-container", None),
+        ("nixpkgs#cowsay", None),
+        ("nixpkgs#cowsay", "my_checkout"),
+        ("nixpkgs#libnvidia-container", None),
     ],
 )
 def test_clean(


### PR DESCRIPTION
Currently the command line can only checkout and build legacy package.
When use it for my own project, I realized a problem, the code I checked out and patched is different from the code I run in the production.
So it turns out we need a way to pin down which code base to patch.
Flake is a great way to do it, but my code doesn't support it well.
Ideally, we should be able to patch any der like:

- `.#hello`
- `/path/to/flake#hello`
- `github:NixOS/nixpkgs/a3a3dda3bacf61e8a39258a0ed9c924eeca8e293#cowsay`
- ...
