### PR TITLE
nix-playground: correct `nix-store` command

### DIFF
--- a/nix_playground/build.py
+++ b/nix_playground/build.py
@@ -39,9 +39,8 @@ def main(env: Environment):
     patch_store_path = (
         subprocess.check_output(
             [
-                "nix",
-                "store",
-                "add",
+                "nix-store",
+                "--add",
                 str(patch_path),
             ]
         )


### PR DESCRIPTION
`np build` fails with:
```python
error: 'add' is not a recognised command
Try 'nix --help' for more information.

  File "/nix/store/5hbr83by8n311xwssgi70r23l2fvrbfa-python3.12-nix-playground-1.0.1/lib/python3.12/site-packages/nix_playground/build.py", line 40, in main
    subprocess.check_output(
  File "/nix/store/wwqdmdr2f5wrjnsjs64bny8df471rh9b-python3-3.12.9/lib/python3.12/subprocess.py", line 468, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/wwqdmdr2f5wrjnsjs64bny8df471rh9b-python3-3.12.9/lib/python3.12/subprocess.py", line 573, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['nix', 'store', 'add', '.nix-playground/checkout.patch']' returned non-zero exit status 1.
```

Applying this patch allows the process to complete without error, and the modified binary appears under `result`, and contains the expected changes.
Let me know if this change is correct, and perhaps `nix-playground` can be inited at 1.0.2?